### PR TITLE
fix: complete THS qfq daily tail after market close

### DIFF
--- a/extend/spider-ths.go
+++ b/extend/spider-ths.go
@@ -8,17 +8,22 @@ import (
 	"github.com/injoyai/tdx"
 	"github.com/injoyai/tdx/protocol"
 	"io"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const (
-	UrlTHSDayKline       = "http://d.10jqka.com.cn/v6/line/hs_%s/0%d/all.js"
-	THS_BFQ        uint8 = 0 //不复权
-	THS_QFQ        uint8 = 1 //前复权
-	THS_HFQ        uint8 = 2 //后复权
+	UrlTHSDayKline         = "http://d.10jqka.com.cn/v6/line/hs_%s/0%d/all.js"
+	UrlTHSTodayKline       = "http://d.10jqka.com.cn/v6/line/hs_%s/0%d/today.js"
+	THS_BFQ          uint8 = 0 //不复权
+	THS_QFQ          uint8 = 1 //前复权
+	THS_HFQ          uint8 = 2 //后复权
 )
+
+var thsHTTPClient = &http.Client{Timeout: 8 * time.Second}
 
 // GetTHSDayKlineFactorFull 增加计算复权因子
 func GetTHSDayKlineFactorFull(code string, c *tdx.Client) ([3][]*Kline, []*THSFactor, error) {
@@ -106,34 +111,7 @@ func GetTHSDayKline(code string, _type uint8) ([]*Kline, error) {
 	}
 
 	u := fmt.Sprintf(UrlTHSDayKline, code[2:], _type)
-	req, err := http.NewRequest(http.MethodGet, u, nil)
-	if err != nil {
-		return nil, err
-	}
-	/*
-	 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) '
-	                      'Chrome/90.0.4430.212 Safari/537.36',
-	        'Referer': 'http://stockpage.10jqka.com.cn/',
-	        'DNT': '1',
-	*/
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36 Edg/89.0.774.54")
-	req.Header.Set("Referer", "http://stockpage.10jqka.com.cn/")
-	req.Header.Set("DNT", "1")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("同花顺日K线HTTP状态异常: %s", resp.Status)
-	}
-	bs, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	bs, err = parseTHSJSONPBody(bs)
+	bs, err := fetchTHSJSONP(u)
 	if err != nil {
 		return nil, err
 	}
@@ -177,22 +155,22 @@ func GetTHSDayKline(code string, _type uint8) ([]*Kline, error) {
 
 	ls := []*Kline(nil)
 	i := 0
-	nowYear := time.Now().Year()
+	nowYear := time.Now().In(shanghaiLocation).Year()
 	for year := 1990; year <= nowYear; year++ {
 		for _, d := range mYear[year] {
 			x, err := time.Parse("0102", d)
 			if err != nil {
 				return nil, err
 			}
-			x = time.Date(year, x.Month(), x.Day(), 15, 0, 0, 0, time.Local)
-			low := protocol.Price(conv.Float64(prices[i*4+0]) * 1000 / priceFactor)
+			x = time.Date(year, x.Month(), x.Day(), 15, 0, 0, 0, shanghaiLocation)
+			low := protocol.Price(math.Round(conv.Float64(prices[i*4+0]) * 1000 / priceFactor))
 			ls = append(ls, &Kline{
 				Code:   protocol.AddPrefix(code),
 				Date:   x.Unix(),
-				Open:   protocol.Price(conv.Float64(prices[i*4+1])*1000/priceFactor) + low,
-				High:   protocol.Price(conv.Float64(prices[i*4+2])*1000/priceFactor) + low,
+				Open:   protocol.Price(math.Round(conv.Float64(prices[i*4+1])*1000/priceFactor)) + low,
+				High:   protocol.Price(math.Round(conv.Float64(prices[i*4+2])*1000/priceFactor)) + low,
 				Low:    low,
-				Close:  protocol.Price(conv.Float64(prices[i*4+3])*1000/priceFactor) + low,
+				Close:  protocol.Price(math.Round(conv.Float64(prices[i*4+3])*1000/priceFactor)) + low,
 				Volume: (conv.Int64(volumes[i]) + 50) / 100,
 			})
 			i++
@@ -200,6 +178,60 @@ func GetTHSDayKline(code string, _type uint8) ([]*Kline, error) {
 	}
 
 	return ls, nil
+}
+
+// GetTHSTodayKline obtains the current daily bar from the THS qfq route.
+func GetTHSTodayKline(code string, _type uint8) (*Kline, error) {
+	if _type != THS_BFQ && _type != THS_QFQ && _type != THS_HFQ {
+		return nil, fmt.Errorf("数据类型错误,例如:不复权0或前复权1或后复权2")
+	}
+
+	code = protocol.AddPrefix(code)
+	if len(code) != 8 {
+		return nil, fmt.Errorf("股票代码错误,例如:SZ000001或000001")
+	}
+
+	u := fmt.Sprintf(UrlTHSTodayKline, code[2:], _type)
+	bs, err := fetchTHSJSONP(u)
+	if err != nil {
+		return nil, err
+	}
+	return parseTHSTodayKline(bs, code)
+}
+
+func fetchTHSJSONP(url string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	/*
+	 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) '
+	                      'Chrome/90.0.4430.212 Safari/537.36',
+	        'Referer': 'http://stockpage.10jqka.com.cn/',
+	        'DNT': '1',
+	*/
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36 Edg/89.0.774.54")
+	req.Header.Set("Referer", "http://stockpage.10jqka.com.cn/")
+	req.Header.Set("DNT", "1")
+	resp, err := thsHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("同花顺日K线HTTP状态异常: %s", resp.Status)
+	}
+	bs, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	bs, err = parseTHSJSONPBody(bs)
+	if err != nil {
+		return nil, err
+	}
+	return bs, nil
 }
 
 func parseTHSJSONPBody(bs []byte) ([]byte, error) {
@@ -217,4 +249,62 @@ func parseTHSJSONPBody(bs []byte) ([]byte, error) {
 		return nil, fmt.Errorf("同花顺日K线JSONP内容为空")
 	}
 	return payload, nil
+}
+
+func parseTHSTodayKline(bs []byte, code string) (*Kline, error) {
+	payload := map[string]map[string]any{}
+	if err := json.Unmarshal(bs, &payload); err != nil {
+		return nil, err
+	}
+	key := "hs_" + code[2:]
+	row, ok := payload[key]
+	if !ok {
+		return nil, fmt.Errorf("同花顺当日日K线缺少标的: %s", code)
+	}
+
+	dateText := conv.String(row["1"])
+	day, err := time.ParseInLocation("20060102", dateText, time.FixedZone("Asia/Shanghai", 8*60*60))
+	if err != nil {
+		return nil, fmt.Errorf("同花顺当日日K线日期无效: %q", dateText)
+	}
+	open, err := parseTHSMilliPrice(row["7"])
+	if err != nil {
+		return nil, fmt.Errorf("同花顺当日日K线开盘价无效: %w", err)
+	}
+	high, err := parseTHSMilliPrice(row["8"])
+	if err != nil {
+		return nil, fmt.Errorf("同花顺当日日K线最高价无效: %w", err)
+	}
+	low, err := parseTHSMilliPrice(row["9"])
+	if err != nil {
+		return nil, fmt.Errorf("同花顺当日日K线最低价无效: %w", err)
+	}
+	closePrice, err := parseTHSMilliPrice(row["11"])
+	if err != nil {
+		return nil, fmt.Errorf("同花顺当日日K线收盘价无效: %w", err)
+	}
+	if high < low || high < open || high < closePrice || low > open || low > closePrice {
+		return nil, fmt.Errorf("同花顺当日日K线OHLC关系无效")
+	}
+
+	return &Kline{
+		Code:  protocol.AddPrefix(code),
+		Date:  time.Date(day.Year(), day.Month(), day.Day(), 15, 0, 0, 0, day.Location()).Unix(),
+		Open:  open,
+		High:  high,
+		Low:   low,
+		Close: closePrice,
+	}, nil
+}
+
+func parseTHSMilliPrice(value any) (protocol.Price, error) {
+	text := strings.TrimSpace(conv.String(value))
+	if text == "" {
+		return 0, fmt.Errorf("价格为空")
+	}
+	parsed, err := strconv.ParseFloat(text, 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) || parsed <= 0 {
+		return 0, fmt.Errorf("价格=%q", text)
+	}
+	return protocol.Price(math.Round(parsed * 1000)), nil
 }

--- a/extend/spider-ths.go
+++ b/extend/spider-ths.go
@@ -125,13 +125,18 @@ func GetTHSDayKline(code string, _type uint8) ([]*Kline, error) {
 	}
 
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("同花顺日K线HTTP状态异常: %s", resp.Status)
+	}
 	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	n := bytes.IndexByte(bs, '(')
-	bs = bs[n+1 : len(bs)-1]
+	bs, err = parseTHSJSONPBody(bs)
+	if err != nil {
+		return nil, err
+	}
 
 	m := map[string]any{}
 	err = json.Unmarshal(bs, &m)
@@ -195,4 +200,21 @@ func GetTHSDayKline(code string, _type uint8) ([]*Kline, error) {
 	}
 
 	return ls, nil
+}
+
+func parseTHSJSONPBody(bs []byte) ([]byte, error) {
+	trimmed := bytes.TrimSpace(bs)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("同花顺日K线返回空响应")
+	}
+	open := bytes.IndexByte(trimmed, '(')
+	close := bytes.LastIndexByte(trimmed, ')')
+	if open < 0 || close <= open {
+		return nil, fmt.Errorf("同花顺日K线返回无效JSONP: bytes=%d", len(trimmed))
+	}
+	payload := bytes.TrimSpace(trimmed[open+1 : close])
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("同花顺日K线JSONP内容为空")
+	}
+	return payload, nil
 }

--- a/extend/spider-ths_test.go
+++ b/extend/spider-ths_test.go
@@ -3,6 +3,9 @@ package extend
 import (
 	"bytes"
 	"testing"
+	"time"
+
+	"github.com/injoyai/tdx/protocol"
 )
 
 func TestParseTHSJSONPBody(t *testing.T) {
@@ -37,6 +40,64 @@ func TestParseTHSJSONPBody(t *testing.T) {
 			}
 			if !bytes.Equal(got, []byte(test.want)) {
 				t.Fatalf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseTHSTodayKline(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    *Kline
+		wantErr bool
+	}{
+		{
+			name: "valid three decimal prices",
+			body: `{"hs_159786":{"1":"20260722","7":"1.237","8":"1.250","9":"1.220","11":"1.245","13":"123456","19":"789012"}}`,
+			want: &Kline{
+				Code:  "SZ159786",
+				Date:  time.Date(2026, 7, 22, 15, 0, 0, 0, time.FixedZone("Asia/Shanghai", 8*60*60)).Unix(),
+				Open:  protocol.Price(1237),
+				High:  protocol.Price(1250),
+				Low:   protocol.Price(1220),
+				Close: protocol.Price(1245),
+			},
+		},
+		{
+			name:    "missing symbol",
+			body:    `{"hs_510300":{"1":"20260722","7":"4.0","8":"4.1","9":"3.9","11":"4.0"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing close",
+			body:    `{"hs_159786":{"1":"20260722","7":"1.237","8":"1.250","9":"1.220"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid ohlc",
+			body:    `{"hs_159786":{"1":"20260722","7":"1.237","8":"1.230","9":"1.220","11":"1.245"}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseTHSTodayKline([]byte(test.body), "SZ159786")
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *got != *test.want {
+				t.Fatalf("got %#v, want %#v", got, test.want)
+			}
+			if got.Volume != 0 || got.Amount != 0 {
+				t.Fatalf("today.js volume/amount must not be trusted: %#v", got)
 			}
 		})
 	}

--- a/extend/spider-ths_test.go
+++ b/extend/spider-ths_test.go
@@ -1,16 +1,43 @@
 package extend
 
 import (
+	"bytes"
 	"testing"
 )
 
-func TestNewSpiderTHS(t *testing.T) {
-	ls, err := GetTHSDayKline("sz000001", THS_HFQ)
-	if err != nil {
-		t.Error(err)
-		return
+func TestParseTHSJSONPBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", body: "", wantErr: true},
+		{name: "whitespace", body: " \n\t", wantErr: true},
+		{name: "missing opener", body: `callback{"status":"ok"})`, wantErr: true},
+		{name: "missing closer", body: `callback({"status":"ok"}`, wantErr: true},
+		{name: "empty payload", body: "callback()", wantErr: true},
+		{
+			name: "valid with trailing semicolon",
+			body: "  callback({\"status\":\"ok\"});\n",
+			want: `{"status":"ok"}`,
+		},
 	}
-	for _, v := range ls {
-		t.Log(v)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseTHSJSONPBody([]byte(test.body))
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(got, []byte(test.want)) {
+				t.Fatalf("got %q, want %q", got, test.want)
+			}
+		})
 	}
 }

--- a/extend/ths-qfq-tail.go
+++ b/extend/ths-qfq-tail.go
@@ -1,0 +1,191 @@
+package extend
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/injoyai/tdx/protocol"
+)
+
+const THSQFQCloseTailCutoffHour = 15
+const THSQFQCloseTailCutoffMinute = 10
+
+var shanghaiLocation = time.FixedZone("Asia/Shanghai", 8*60*60)
+
+type THSQFQTailResult struct {
+	Klines      []*Kline
+	Source      string
+	VerifiedBy  string
+	TradeDate   string
+	CurrentDate bool
+}
+
+// CompleteTHSQFQDailyTail verifies the last completed qfq daily bar against
+// TDX raw data and appends the strictly validated today.js bar when all.js
+// has not published the completed tail yet.
+func CompleteTHSQFQDailyTail(
+	all []*Kline,
+	raw []*protocol.Kline,
+	fetchToday func() (*Kline, error),
+	now time.Time,
+) (*THSQFQTailResult, error) {
+	if len(all) == 0 {
+		return nil, fmt.Errorf("同花顺前复权 all.js 数据为空")
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("TDX 原始日K线数据为空，无法核验同花顺前复权尾部")
+	}
+	if err := validateUniqueKlineDates(all); err != nil {
+		return nil, err
+	}
+	if err := validateUniqueRawDates(raw); err != nil {
+		return nil, err
+	}
+
+	qfq := append([]*Kline(nil), all...)
+	sort.Slice(qfq, func(i, j int) bool { return qfq[i].Date < qfq[j].Date })
+	rawBars := append([]*protocol.Kline(nil), raw...)
+	sort.Slice(rawBars, func(i, j int) bool { return rawBars[i].Time.Before(rawBars[j].Time) })
+
+	nowShanghai := now.In(shanghaiLocation)
+	today := dateKey(nowShanghai)
+	cutoff := time.Date(
+		nowShanghai.Year(), nowShanghai.Month(), nowShanghai.Day(),
+		THSQFQCloseTailCutoffHour, THSQFQCloseTailCutoffMinute, 0, 0,
+		shanghaiLocation,
+	)
+	rawLast := rawBars[len(rawBars)-1]
+	rawLastDate := dateKey(rawLast.Time.In(shanghaiLocation))
+
+	// TDX may expose an in-progress daily bar during the session. Never return
+	// the matching THS row before the close-tail cutoff, even if all.js has it.
+	if rawLastDate == today && nowShanghai.Before(cutoff) {
+		qfq = filterKlinesBefore(qfq, today)
+		if len(qfq) == 0 {
+			return nil, fmt.Errorf("15:10 前同花顺前复权数据没有已完成历史日K线")
+		}
+		return &THSQFQTailResult{
+			Klines:    qfq,
+			Source:    "ths_all",
+			TradeDate: dateKey(time.Unix(qfq[len(qfq)-1].Date, 0).In(shanghaiLocation)),
+		}, nil
+	}
+
+	qfqLastDate := dateKey(time.Unix(qfq[len(qfq)-1].Date, 0).In(shanghaiLocation))
+	if qfqLastDate > rawLastDate {
+		return nil, fmt.Errorf("同花顺前复权尾部日期 %s 晚于 TDX 原始日线 %s", qfqLastDate, rawLastDate)
+	}
+
+	source := "ths_all"
+	if qfqLastDate < rawLastDate {
+		if fetchToday == nil {
+			return nil, fmt.Errorf("同花顺 all.js 缺少 %s 且 today.js 获取器不可用", rawLastDate)
+		}
+		todayKline, err := fetchToday()
+		if err != nil {
+			return nil, fmt.Errorf("同花顺 all.js 缺少 %s，today.js 获取失败: %w", rawLastDate, err)
+		}
+		if todayKline == nil {
+			return nil, fmt.Errorf("同花顺 all.js 缺少 %s，today.js 返回空数据", rawLastDate)
+		}
+		todayDate := dateKey(time.Unix(todayKline.Date, 0).In(shanghaiLocation))
+		if todayDate != rawLastDate {
+			return nil, fmt.Errorf("同花顺 today.js 日期 %s 与 TDX 原始日线 %s 不一致", todayDate, rawLastDate)
+		}
+		qfq = append(qfq, todayKline)
+		source = "ths_today"
+	}
+
+	tail := qfq[len(qfq)-1]
+	if err := verifyTailOHLC(tail, rawLast); err != nil {
+		return nil, err
+	}
+	tail.Volume = rawLast.Volume
+	tail.Amount = rawLast.Amount
+
+	return &THSQFQTailResult{
+		Klines:      qfq,
+		Source:      source,
+		VerifiedBy:  "tdx_raw_daily",
+		TradeDate:   rawLastDate,
+		CurrentDate: rawLastDate == today,
+	}, nil
+}
+
+func validateUniqueKlineDates(klines []*Kline) error {
+	seen := make(map[string]struct{}, len(klines))
+	for _, kline := range klines {
+		if kline == nil {
+			return fmt.Errorf("同花顺前复权 all.js 包含空K线")
+		}
+		date := dateKey(time.Unix(kline.Date, 0).In(shanghaiLocation))
+		if _, exists := seen[date]; exists {
+			return fmt.Errorf("同花顺前复权 all.js 包含重复日期: %s", date)
+		}
+		seen[date] = struct{}{}
+	}
+	return nil
+}
+
+func validateUniqueRawDates(klines []*protocol.Kline) error {
+	seen := make(map[string]struct{}, len(klines))
+	for _, kline := range klines {
+		if kline == nil {
+			return fmt.Errorf("TDX 原始日线包含空K线")
+		}
+		date := dateKey(kline.Time.In(shanghaiLocation))
+		if _, exists := seen[date]; exists {
+			return fmt.Errorf("TDX 原始日线包含重复日期: %s", date)
+		}
+		seen[date] = struct{}{}
+	}
+	return nil
+}
+
+func filterKlinesBefore(klines []*Kline, date string) []*Kline {
+	filtered := make([]*Kline, 0, len(klines))
+	for _, kline := range klines {
+		if dateKey(time.Unix(kline.Date, 0).In(shanghaiLocation)) < date {
+			filtered = append(filtered, kline)
+		}
+	}
+	return filtered
+}
+
+func verifyTailOHLC(qfq *Kline, raw *protocol.Kline) error {
+	qfqDate := dateKey(time.Unix(qfq.Date, 0).In(shanghaiLocation))
+	rawDate := dateKey(raw.Time.In(shanghaiLocation))
+	if qfqDate != rawDate {
+		return fmt.Errorf("同花顺前复权尾部日期 %s 与 TDX 原始日线 %s 不一致", qfqDate, rawDate)
+	}
+	if err := validateOHLC(qfq.Open, qfq.High, qfq.Low, qfq.Close); err != nil {
+		return fmt.Errorf("%s 同花顺前复权尾部 OHLC 无效: %w", qfqDate, err)
+	}
+	if err := validateOHLC(raw.Open, raw.High, raw.Low, raw.Close); err != nil {
+		return fmt.Errorf("%s TDX 原始日线 OHLC 无效: %w", rawDate, err)
+	}
+	if qfq.Open != raw.Open || qfq.High != raw.High || qfq.Low != raw.Low || qfq.Close != raw.Close {
+		return fmt.Errorf(
+			"%s 同花顺前复权与 TDX 原始日线 OHLC 不一致: THS=%d/%d/%d/%d TDX=%d/%d/%d/%d",
+			qfqDate,
+			qfq.Open, qfq.High, qfq.Low, qfq.Close,
+			raw.Open, raw.High, raw.Low, raw.Close,
+		)
+	}
+	return nil
+}
+
+func validateOHLC(open, high, low, close protocol.Price) error {
+	if open <= 0 || high <= 0 || low <= 0 || close <= 0 {
+		return fmt.Errorf("价格必须为正数")
+	}
+	if high < low || high < open || high < close || low > open || low > close {
+		return fmt.Errorf("OHLC 关系不成立")
+	}
+	return nil
+}
+
+func dateKey(value time.Time) string {
+	return value.Format("2006-01-02")
+}

--- a/extend/ths-qfq-tail_test.go
+++ b/extend/ths-qfq-tail_test.go
@@ -1,0 +1,219 @@
+package extend
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/injoyai/tdx/protocol"
+)
+
+func TestCompleteTHSQFQDailyTail(t *testing.T) {
+	previous := testTHSKline("2026-07-21", 1200, 1230, 1190, 1210)
+	current := testTHSKline("2026-07-22", 1210, 1250, 1200, 1240)
+	rawPrevious := testRawKline("2026-07-21", 1200, 1230, 1190, 1210)
+	rawCurrent := testRawKline("2026-07-22", 1210, 1250, 1200, 1240)
+
+	tests := []struct {
+		name        string
+		all         []*Kline
+		raw         []*protocol.Kline
+		now         time.Time
+		today       *Kline
+		todayErr    error
+		wantSource  string
+		wantDate    string
+		wantLen     int
+		wantFetches int
+		wantErr     bool
+	}{
+		{
+			name:       "before cutoff excludes current date",
+			all:        []*Kline{previous, current},
+			raw:        []*protocol.Kline{rawPrevious, rawCurrent},
+			now:        testShanghaiTime("2026-07-22 15:09"),
+			wantSource: "ths_all",
+			wantDate:   "2026-07-21",
+			wantLen:    1,
+		},
+		{
+			name:       "market close still excludes current date",
+			all:        []*Kline{previous, current},
+			raw:        []*protocol.Kline{rawPrevious, rawCurrent},
+			now:        testShanghaiTime("2026-07-22 15:00"),
+			wantSource: "ths_all",
+			wantDate:   "2026-07-21",
+			wantLen:    1,
+		},
+		{
+			name:       "at cutoff uses complete all tail",
+			all:        []*Kline{previous, current},
+			raw:        []*protocol.Kline{rawPrevious, rawCurrent},
+			now:        testShanghaiTime("2026-07-22 15:10"),
+			wantSource: "ths_all",
+			wantDate:   "2026-07-22",
+			wantLen:    2,
+		},
+		{
+			name:        "after cutoff appends today tail",
+			all:         []*Kline{previous},
+			raw:         []*protocol.Kline{rawPrevious, rawCurrent},
+			now:         testShanghaiTime("2026-07-22 16:00"),
+			today:       current,
+			wantSource:  "ths_today",
+			wantDate:    "2026-07-22",
+			wantLen:     2,
+			wantFetches: 1,
+		},
+		{
+			name:       "weekend verifies latest closed day",
+			all:        []*Kline{previous},
+			raw:        []*protocol.Kline{rawPrevious},
+			now:        testShanghaiTime("2026-07-25 10:00"),
+			wantSource: "ths_all",
+			wantDate:   "2026-07-21",
+			wantLen:    1,
+		},
+		{
+			name:        "today fetch failure is explicit",
+			all:         []*Kline{previous},
+			raw:         []*protocol.Kline{rawPrevious, rawCurrent},
+			now:         testShanghaiTime("2026-07-22 16:00"),
+			todayErr:    errors.New("timeout"),
+			wantErr:     true,
+			wantFetches: 1,
+		},
+		{
+			name:        "today date mismatch fails",
+			all:         []*Kline{previous},
+			raw:         []*protocol.Kline{rawPrevious, rawCurrent},
+			now:         testShanghaiTime("2026-07-22 16:00"),
+			today:       testTHSKline("2026-07-21", 1210, 1250, 1200, 1240),
+			wantErr:     true,
+			wantFetches: 1,
+		},
+		{
+			name:    "price mismatch fails",
+			all:     []*Kline{previous, testTHSKline("2026-07-22", 1211, 1250, 1200, 1240)},
+			raw:     []*protocol.Kline{rawPrevious, rawCurrent},
+			now:     testShanghaiTime("2026-07-22 16:00"),
+			wantErr: true,
+		},
+		{
+			name:    "empty raw ohlc fails",
+			all:     []*Kline{previous, current},
+			raw:     []*protocol.Kline{rawPrevious, testRawKline("2026-07-22", 0, 0, 0, 0)},
+			now:     testShanghaiTime("2026-07-22 16:00"),
+			wantErr: true,
+		},
+		{
+			name:    "duplicate all date fails",
+			all:     []*Kline{previous, previous},
+			raw:     []*protocol.Kline{rawPrevious},
+			now:     testShanghaiTime("2026-07-25 10:00"),
+			wantErr: true,
+		},
+		{
+			name: "ex-right history does not compare older raw prices",
+			all: []*Kline{
+				testTHSKline("2026-07-20", 600, 620, 590, 610),
+				previous,
+			},
+			raw: []*protocol.Kline{
+				testRawKline("2026-07-20", 1200, 1240, 1180, 1220),
+				rawPrevious,
+			},
+			now:        testShanghaiTime("2026-07-21 16:00"),
+			wantSource: "ths_all",
+			wantDate:   "2026-07-21",
+			wantLen:    2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fetches := 0
+			result, err := CompleteTHSQFQDailyTail(test.all, test.raw, func() (*Kline, error) {
+				fetches++
+				return test.today, test.todayErr
+			}, test.now)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %#v", result)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if result.Source != test.wantSource || result.TradeDate != test.wantDate || len(result.Klines) != test.wantLen {
+					t.Fatalf("unexpected result: %#v", result)
+				}
+				if result.VerifiedBy != "" && result.VerifiedBy != "tdx_raw_daily" {
+					t.Fatalf("unexpected verifier: %q", result.VerifiedBy)
+				}
+			}
+			if fetches != test.wantFetches {
+				t.Fatalf("today fetch count=%d, want %d", fetches, test.wantFetches)
+			}
+		})
+	}
+}
+
+func TestCompleteTHSQFQDailyTailUsesRawVolumeAndAmount(t *testing.T) {
+	all := testTHSKline("2026-07-22", 1210, 1250, 1200, 1240)
+	all.Volume = 1
+	all.Amount = 2
+	raw := testRawKline("2026-07-22", 1210, 1250, 1200, 1240)
+	raw.Volume = 998877
+	raw.Amount = 776655
+
+	result, err := CompleteTHSQFQDailyTail(
+		[]*Kline{all},
+		[]*protocol.Kline{raw},
+		nil,
+		testShanghaiTime("2026-07-22 16:00"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Klines[0].Volume != raw.Volume || result.Klines[0].Amount != raw.Amount {
+		t.Fatalf("tail did not use raw volume/amount: %#v", result.Klines[0])
+	}
+}
+
+func testTHSKline(date string, open, high, low, close protocol.Price) *Kline {
+	return &Kline{
+		Code:  "SZ159786",
+		Date:  testDate(date).Unix(),
+		Open:  open,
+		High:  high,
+		Low:   low,
+		Close: close,
+	}
+}
+
+func testRawKline(date string, open, high, low, close protocol.Price) *protocol.Kline {
+	return &protocol.Kline{
+		Time:  testDate(date),
+		Open:  open,
+		High:  high,
+		Low:   low,
+		Close: close,
+	}
+}
+
+func testDate(value string) time.Time {
+	parsed, err := time.ParseInLocation("2006-01-02", value, shanghaiLocation)
+	if err != nil {
+		panic(err)
+	}
+	return time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 15, 0, 0, 0, shanghaiLocation)
+}
+
+func testShanghaiTime(value string) time.Time {
+	parsed, err := time.ParseInLocation("2006-01-02 15:04", value, shanghaiLocation)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}

--- a/web/server.go
+++ b/web/server.go
@@ -171,23 +171,54 @@ func handleGetKline(w http.ResponseWriter, r *http.Request) {
 
 // getQfqKlineDay 获取前复权日K线数据
 func getQfqKlineDay(code string) (*protocol.KlineResp, error) {
+	resp, _, err := getQfqKlineDayDetailed(code, time.Now())
+	return resp, err
+}
+
+type qfqKlineMetadata struct {
+	TailSource     string
+	TailVerifiedBy string
+	TailTradeDate  string
+}
+
+var qfqShanghaiLocation = time.FixedZone("Asia/Shanghai", 8*60*60)
+
+func getQfqKlineDayDetailed(code string, now time.Time) (*protocol.KlineResp, qfqKlineMetadata, error) {
 	// 使用同花顺API获取前复权数据
 	klines, err := extend.GetTHSDayKline(code, extend.THS_QFQ)
 	if err != nil {
-		return nil, fmt.Errorf("获取前复权数据失败: %w", err)
+		return nil, qfqKlineMetadata{}, fmt.Errorf("获取前复权数据失败: %w", err)
 	}
 
 	if len(klines) == 0 {
-		return nil, fmt.Errorf("同花顺前复权数据为空")
+		return nil, qfqKlineMetadata{}, fmt.Errorf("同花顺前复权数据为空")
 	}
 
-	// 从 TDX 获取原始 K 线补充成交额（THS 接口不返回 Amount）
+	// TDX 原始日线既提供成交量/成交额，也作为收盘尾部的严格裁判。
 	tdxResp, tdxErr := client.GetKlineDayAll(code)
-	amountMap := make(map[int64]protocol.Price)
-	if tdxErr == nil && tdxResp != nil {
-		for _, v := range tdxResp.List {
-			amountMap[v.Time.Unix()] = v.Amount
-		}
+	if tdxErr != nil {
+		return nil, qfqKlineMetadata{}, fmt.Errorf("获取 TDX 原始日线用于前复权尾部核验失败: %w", tdxErr)
+	}
+	if tdxResp == nil || len(tdxResp.List) == 0 {
+		return nil, qfqKlineMetadata{}, fmt.Errorf("TDX 原始日线为空，无法核验同花顺前复权尾部")
+	}
+
+	tail, err := extend.CompleteTHSQFQDailyTail(
+		klines,
+		tdxResp.List,
+		func() (*extend.Kline, error) {
+			return extend.GetTHSTodayKline(code, extend.THS_QFQ)
+		},
+		now,
+	)
+	if err != nil {
+		return nil, qfqKlineMetadata{}, fmt.Errorf("核验同花顺前复权收盘尾部失败: %w", err)
+	}
+	klines = tail.Klines
+
+	amountMap := make(map[string]protocol.Price)
+	for _, v := range tdxResp.List {
+		amountMap[v.Time.In(qfqShanghaiLocation).Format("2006-01-02")] = v.Amount
 	}
 
 	// 转换为 protocol.KlineResp 格式
@@ -207,8 +238,9 @@ func getQfqKlineDay(code string) (*protocol.KlineResp, error) {
 			Amount: k.Amount,
 		}
 		// 从 TDX 数据补充成交额
-		if pk.Amount == 0 && amountMap != nil {
-			if amt, ok := amountMap[k.Date]; ok {
+		if pk.Amount == 0 {
+			date := time.Unix(k.Date, 0).In(qfqShanghaiLocation).Format("2006-01-02")
+			if amt, ok := amountMap[date]; ok {
 				pk.Amount = amt
 			}
 		}
@@ -219,7 +251,11 @@ func getQfqKlineDay(code string) (*protocol.KlineResp, error) {
 		resp.List = append(resp.List, pk)
 	}
 
-	return resp, nil
+	return resp, qfqKlineMetadata{
+		TailSource:     tail.Source,
+		TailVerifiedBy: tail.VerifiedBy,
+		TailTradeDate:  tail.TradeDate,
+	}, nil
 }
 
 // convertToWeekKline 将日K线转换为周K线（简化版）

--- a/web/server_api_extended.go
+++ b/web/server_api_extended.go
@@ -783,7 +783,7 @@ func handleGetKlineAllTHS(w http.ResponseWriter, r *http.Request) {
 	}
 	limit := parsePositiveInt(r.URL.Query().Get("limit"))
 
-	list, err := fetchStockKlineAllTHS(code, klineType)
+	list, tailMeta, err := fetchStockKlineAllTHS(code, klineType)
 	if err != nil {
 		errorResponse(w, fmt.Sprintf("获取同花顺K线失败: %v", err))
 		return
@@ -793,7 +793,11 @@ func handleGetKlineAllTHS(w http.ResponseWriter, r *http.Request) {
 		list = list[len(list)-limit:]
 	}
 
-	respondKlineSuccess(w, "ths", klineType, list)
+	respondKlineSuccessWithMeta(w, "ths", klineType, list, map[string]interface{}{
+		"tail_source":      tailMeta.TailSource,
+		"tail_verified_by": tailMeta.TailVerifiedBy,
+		"tail_trade_date":  tailMeta.TailTradeDate,
+	})
 }
 
 // 获取交易日信息
@@ -1218,25 +1222,29 @@ func fetchStockKlineAllTDX(code, klineType string) ([]*protocol.Kline, error) {
 	}
 }
 
-func fetchStockKlineAllTHS(code, klineType string) ([]*protocol.Kline, error) {
-	resp, err := getQfqKlineDay(code)
+func fetchStockKlineAllTHS(code, klineType string) ([]*protocol.Kline, qfqKlineMetadata, error) {
+	resp, meta, err := getQfqKlineDayDetailed(code, time.Now())
 	if err != nil {
-		return nil, err
+		return nil, qfqKlineMetadata{}, err
 	}
 
 	switch strings.ToLower(klineType) {
 	case "", "day":
-		return resp.List, nil
+		return resp.List, meta, nil
 	case "week":
-		return convertToWeekKline(resp).List, nil
+		return convertToWeekKline(resp).List, meta, nil
 	case "month":
-		return convertToMonthKline(resp).List, nil
+		return convertToMonthKline(resp).List, meta, nil
 	default:
-		return nil, fmt.Errorf("同花顺接口暂仅支持 type=day/week/month")
+		return nil, qfqKlineMetadata{}, fmt.Errorf("同花顺接口暂仅支持 type=day/week/month")
 	}
 }
 
 func respondKlineSuccess(w http.ResponseWriter, source, klineType string, list []*protocol.Kline) {
+	respondKlineSuccessWithMeta(w, source, klineType, list, nil)
+}
+
+func respondKlineSuccessWithMeta(w http.ResponseWriter, source, klineType string, list []*protocol.Kline, extraMeta map[string]interface{}) {
 	kType := strings.ToLower(klineType)
 	meta := map[string]interface{}{
 		"source": source,
@@ -1258,6 +1266,11 @@ func respondKlineSuccess(w http.ResponseWriter, source, klineType string, list [
 		}
 	default:
 		meta["notes"] = []string{"未知数据源，请检查 source 参数"}
+	}
+	for key, value := range extraMeta {
+		if value != "" {
+			meta[key] = value
+		}
 	}
 
 	successResponse(w, map[string]interface{}{


### PR DESCRIPTION
## Summary

`all.js` is an asynchronously generated full-history file. In a post-close sample of 18 public ETFs, only 5 of 18 `all.js` responses contained the completed current trading day, while `today.js` returned that day for all 18 symbols. The OHLC values from all 18 `today.js` responses matched the corresponding TDX raw daily OHLC exactly at the API integer price precision.

This change keeps `all.js` as the qfq history source and, after 15:10 Asia/Shanghai, appends `today.js` only when the completed TDX trading date is missing. The admitted tail must have:

- the same date as the latest completed TDX raw daily bar;
- positive, internally valid OHLC values;
- exact open/high/low/close agreement with TDX raw daily data at 0.001 CNY integer precision.

Volume and amount for the admitted tail come from the same-date TDX raw daily bar. A missing field, duplicate date, timeout, stale date, or price mismatch returns an explicit error. Before 15:10, a current-date daily row is excluded even if a source exposes it.

`last.js` is intentionally not used because observed responses can contain zero-price placeholders, stale values, and intraday fragments. Existing historical qfq behavior is unchanged.

## Reproduction

The sample used these public symbols:

`159509`, `159786`, `159915`, `161226`, `513050`, `513080`, `513730`, `515120`, `516780`, `518680`, `588000`, `588130`, `588170`, `588200`, `588790`, `588830`, `589070`, `589120`.

For any symbol, compare the qfq history and close-tail responses:

```bash
curl 'http://d.10jqka.com.cn/v6/line/hs_159786/01/all.js'
curl 'http://d.10jqka.com.cn/v6/line/hs_159786/01/today.js'
curl 'http://127.0.0.1:8080/api/kline-all/tdx?code=SZ159786&type=day&limit=1'
```

Decode the JSONP payloads, compare the final dates, then compare the four OHLC fields after converting CNY prices to integer milliyuan. The added table-driven tests reproduce the time gates and validation without depending on a live endpoint.

## Tests

```bash
go test ./...
(cd web && go test ./...)
```

Coverage includes before/at the 15:10 cutoff, weekends, complete `all.js`, `today.js` tail completion, duplicate dates, empty/invalid fields, price mismatches, request failure, raw volume/amount ownership, and an ex-right history case.
